### PR TITLE
Added usb and dc jack outlines, as per Matthew Beckler's dimensions in svg drawing

### DIFF
--- a/pcb/arduino_mega.pcb
+++ b/pcb/arduino_mega.pcb
@@ -1,11 +1,11 @@
-# release: pcb 1.99z
+# release: pcb 20140316
 
 # To read pcb files, the pcb version (or the git source date) must be >= the file version
 FileVersion[20091103]
 
 PCB["" 5983.00mil 3239.00mil]
 
-Grid[2500.000000 14.70mil 21.40mil 1]
+Grid[500.000000 14.70mil 21.40mil 1]
 PolyArea[3100.006200]
 Thermal[0.500000]
 DRC[10.00mil 10.00mil 10.00mil 10.00mil 15.00mil 10.00mil]
@@ -785,7 +785,7 @@ Symbol['~' 12.00mil]
 	SymbolLine[15.00mil 35.00mil 20.00mil 35.00mil 8.00mil]
 	SymbolLine[20.00mil 35.00mil 25.00mil 30.00mil 8.00mil]
 )
-Attribute("PCB::grid::size" "25.00mil")
+Attribute("PCB::grid::size" "5.00mil")
 Attribute("PCB::grid::unit" "mil")
 
 Element["" "Header connector, ribbon cable numbering" "" "DIGITAL" 4524.30mil 371.70mil 210.00mil -50.00mil 3 100 ""]
@@ -1020,6 +1020,14 @@ Layer(8 "spare")
 	Line[4624.70mil 271.40mil 4724.70mil 371.40mil 5.00mil 40.00mil "clearline"]
 	Line[2624.50mil 371.40mil 2624.50mil 271.40mil 5.00mil 40.00mil "clearline"]
 	Line[1564.70mil 371.40mil 1564.70mil 271.40mil 5.00mil 40.00mil "clearline"]
+	Line[1199.70mil 646.40mil 574.70mil 646.40mil 5.00mil 40.00mil "clearline"]
+	Line[1199.70mil 1146.40mil 574.70mil 1146.40mil 5.00mil 40.00mil "clearline"]
+	Line[574.70mil 646.40mil 574.70mil 1146.40mil 5.00mil 40.00mil "clearline"]
+	Line[1199.70mil 646.40mil 1199.70mil 1146.40mil 5.00mil 40.00mil "clearline"]
+	Line[749.70mil 1896.40mil 1274.70mil 1896.40mil 5.00mil 40.00mil "clearline"]
+	Line[749.70mil 2251.40mil 1274.70mil 2251.40mil 5.00mil 40.00mil "clearline"]
+	Line[749.70mil 1896.40mil 749.70mil 2251.40mil 5.00mil 40.00mil "clearline"]
+	Line[1274.70mil 1896.40mil 1274.70mil 2251.40mil 5.00mil 40.00mil "clearline"]
 	Arc[864.70mil 311.40mil 40.00mil 40.00mil 5.00mil 40.00mil 0 -90 "clearline"]
 	Arc[859.70mil 2336.40mil 35.00mil 35.00mil 5.00mil 40.00mil 90 -90 "clearline"]
 	Arc[4689.70mil 2336.40mil 35.00mil 35.00mil 5.00mil 40.00mil 180 -90 "clearline"]


### PR DESCRIPTION
[Here's the svg](https://www.wayneandlayne.com/blog/2010/12/19/nice-drawings-of-the-arduino-uno-and-mega-2560/)